### PR TITLE
Fix a memset with an incorrect size

### DIFF
--- a/src/lib/mg/rib/mgribtoken.c
+++ b/src/lib/mg/rib/mgribtoken.c
@@ -191,7 +191,7 @@ void mrti_delete(TokenBuffer *tkbuf)
 	if (_tokenbuffer == tkbuf) {
 	    _tokenbuffer = NULL;
 	}
-	memset(tkbuf, 0, sizeof(tkbuf));
+	memset(tkbuf, 0, sizeof(*tkbuf));
     }
 }
 


### PR DESCRIPTION
Recent versions of GCC warn that the size passed to this `memset` call is not correct:
```
mgribtoken.c: In function 'mrti_delete':
mgribtoken.c:194:32: warning: argument to 'sizeof' in 'memset' call is the same expression as the destination; did you mean to dereference it? [-Wsizeof-pointer-memaccess]
  194 |         memset(tkbuf, 0, sizeof(tkbuf));
      |                                ^
```
